### PR TITLE
Removed hubot as dependency to fix warnings on install + fixed command spelling error

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   },
 
   "peerDependencies": {
-    "hubot": "2.x"
   },
 
   "devDependencies": {
@@ -31,7 +30,6 @@
     "grunt-contrib-watch": "~0.6.1",
     "grunt-mocha-test": "~0.12.7",
     "grunt-release": "~0.11.0",
-    "hubot": "2.x",
     "matchdep": "~0.3.0",
     "mocha": "^2.1.0",
     "sinon": "^1.13.0",

--- a/src/mlbot.coffee
+++ b/src/mlbot.coffee
@@ -10,7 +10,7 @@
 # Commands:
 #   how bout|about them|those <team name> - tells you how your team did yesterday
 #   standings - gives you the standings for each MLB division
-#   standdings alw|alc|ale|nlw|nlc|nle - gives you divisional standings
+#   standings alw|alc|ale|nlw|nlc|nle - gives you divisional standings
 #
 # Author:
 # craigrow


### PR DESCRIPTION
*Fixed error in command for 'mlbstandings'
There was a spelling mistake in the commands list of 'standdings' instead of 'standings'.  This gave incorrect information when running 'hubot help'.

*Removed Hubot as a dependency
This doesn't appear to be required and there would really be no way as far as I know to run this hubot script without hubot itself and is giving warnings when installing because we are on hubot v3 already.  It doesn't appear other scripts list hubot as a dependency so rather than do some sort of 3.0 >=2.x style thing, I figured it would be best to remove the dependency altogether.